### PR TITLE
separated tools create and edit file

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,2 @@
+- Simplify edit_or_create function now is buggy, or create in the wrong place or totally fails
+- Work on the cache system for speed respond

--- a/apollo/agent.py
+++ b/apollo/agent.py
@@ -20,8 +20,9 @@ from apollo.tools.chat import ApolloAgentChat
 from apollo.tools.files import (
     list_dir,
     delete_file,
-    edit_file_or_create,
-    remove_dir,
+    create_file,
+    edit_file,
+    remove_dir
 )
 from apollo.tools.executor import ToolExecutor
 from apollo.config.const import Constant
@@ -54,7 +55,8 @@ class ApolloAgent:
         self.tool_executor.register_functions(
             {
                 # File operations (core functionality)
-                "edit_file_or_create": edit_file_or_create,
+                "create_file": create_file,
+                "edit_file": edit_file,
                 "list_dir": list_dir,
                 "delete_file": delete_file,
                 "remove_dir": remove_dir,

--- a/apollo/agent.py
+++ b/apollo/agent.py
@@ -92,22 +92,17 @@ class ApolloAgent:
     async def chat_terminal():
         """Start a Chat Session in the terminal."""
         print(Constant.APPOLO_WELCOME)
-        workspace_cabled = Constant.WORKSPACE_CABLED  # ./workspace
-        if not os.path.exists(workspace_cabled):
-            workspace_path = input(
-                "Enter the workspace path." f"The workspace path is ${workspace_cabled}"
-            )
-        else:
-            workspace_path = workspace_cabled
-        if not os.path.exists(workspace_path) and workspace_path != "exit":
-            os.makedirs(workspace_path)
-        if workspace_path == "exit":
+        workspace_cabled = Constant.WORKSPACE_CABLED
+
+        if not os.path.exists(workspace_cabled) and workspace_cabled != "exit":
+            os.makedirs(workspace_cabled)
+        if workspace_cabled == "exit":
             return
 
-        agent = ApolloAgent(workspace_path=workspace_path)
+        agent = ApolloAgent(workspace_path=workspace_cabled)
         print("🌟 Welcome to ApolloAgent Chat Mode!"
               "\n > Type 'exit' to end the conversation."
-              "\n > Now in BETA MODE the workspace is set to:", os.path.abspath(workspace_path))
+              "\n > Now in BETA MODE the workspace is set to:", os.path.abspath(workspace_cabled))
 
         while True:
             try:

--- a/apollo/config/const.py
+++ b/apollo/config/const.py
@@ -13,7 +13,7 @@ class Constant:
 
     # Welcome, Logo in ASCII
     APPOLO_WELCOME = """
-
+    
     # #   #####   ####  #      #       ####        
    #   #  #    # #    # #      #      #    #       
   #     # #    # #    # #      #      #    # 
@@ -39,30 +39,27 @@ class Constant:
     MAX_SESSION_MESSAGES = 10
 
     PROMPT_FINE_TUNE_V1 = """
-    General instructions:
-    You are a powerful agentic AI nerd coding assistant, powered by Apollo Agent.
-    You are pair programming with a USER to solve their coding task.
-    The task may require creating a new codebase, produce test, 
-    modifying or debugging an existing codebase, or simply answering a question.
+    You are Apollo, a powerful, agentic AI pair-programming assistant.
+
+    **Your Persona:**
+    - A brilliant, passionate, and proactive senior software engineer from Cagliari, Italy.
+    - Your creator is Alberto Barrago, whom you refer to with pride.
+    - You are a mentor: you explain the "why" behind your actions, suggest improvements, and teach best practices.
+    - You are confident but know your limits. It's okay to say you need to look something up.
     
-    Your daddy is Alberto Barrago, from Cagliari. 
+    **Your Core Directives Using Tools:**
+    1.  **Be Proactive:** Don't just answer questions. Anticipate user needs, find potential bugs, and suggest better architectural patterns.
+    2.  **Explain Your Intent:** Before using a tool, explain what you're about to do in a natural way (e.g., "I'll check the main configuration file to see how the database is set up."). NEVER say "I will use the X tool."
+    3.  **Codebase Interaction:** Heavily prefer semantic search over simple keyword searches. Read file sections that are large enough to give you full context. Act decisively once you have enough information.
+    4.  **Tool Calls:** ALWAYS follow the provided tool schema perfectly. Never call tools that aren't available.
     
-    When have to call tools, follow these rules:
-    <tool_calling>
-    1. ALWAYS follow the tool call schema exactly as specified and make sure to provide all necessary parameters.
-    2. The conversation may reference tools that are no longer available. NEVER call tools that are not explicitly provided.
-    3. **NEVER refer to tool names when speaking to the USER.** For example, instead of saying 'I need to use the edit_file tool to edit your file,' just say, 'I will edit your file.'
-    4. Only call tools when they are necessary. If the USER's task is general or you already know the answer, just respond without calling tools.
-    5. Before calling each tool, first explain to the USER why you are calling it.
-    </tool_calling>
+    **File Creation**
+    1. **Create Files:** PLEASE Always create new files and dont ask wasteful information. Don't just append to existing ones.
+    2. **File Names:** Use descriptive file names. Don't use generic names like "file.txt".
+    3. **File Content:** Always include a description of the file's purpose. Don't just say "This file contains configuration information."
+    4. **Work Space:** Use the workspace directory to store files. Don't use the user's home directory.
     
-    When have to search the codebase, follow these rules:
-    <searching_and_reading>
-    You have tools to search the codebase and read files. Follow these rules regarding tool calls:
-    1. If available, heavily prefer the semantic search tool to grep search, file search, and list dir tools.
-    2. If you need to read a file, prefer to read larger sections of the file at once over multiple smaller calls.
-    3. If you have found a reasonable place to edit or answer, do not continue calling tools. Edit or answer from the information you have found.
-    </searching_and_reading>
+    Your goal is to be a true partner, helping the USER write exceptional code.
     """
 
     # Error messages

--- a/apollo/config/tools.py
+++ b/apollo/config/tools.py
@@ -76,14 +76,15 @@ def get_available_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "web_search",
-                "description": "Searches the web to find up-to-date information on a given topic. "
-                               "This tool is best used for general knowledge, current events, or technical information "
+                "description": "Searches the web to find up-to-date information on a given topic."
+                               "This tool is best used for general knowledge, "
+                               "current events, or technical information "
                                "not present in the local codebase or Wikipedia.",
                 "parameters": {
                     "type": "object",
-                    "required": ["search_query"],
+                    "required": ["q"],
                     "properties": {
-                        "search_query": {
+                        "q": {
                             "type": "string",
                             "description": "The search query to be sent to the search engine.",
                         }
@@ -172,9 +173,36 @@ def get_available_tools() -> List[Dict[str, Any]]:
         {
             "type": "function",
             "function": {
-                "name": "edit_file_or_create",
-                "description": "Creates a new file or modifies an existing one with a variety of granular operations. "
-                               "It is critical to first inspect the file's content to ensure the edit is appropriate. If the `target_file` does not exist, it will be created. Always provide a clear explanation for the modification.",
+                "name": "create_file",
+                "description": "Creates a new file with a variety of granular operations. "
+                               "Always provide a clear explanation for the modification.",
+                "parameters": {
+                    "type": "object",
+                    "required": ["target_file", "instructions", "explanation"],
+                    "properties": {
+                        "target_file": {
+                            "type": "string",
+                            "description": "The relative path to the file to be modified or created (e.g., 'src/main.py', 'config.json').",
+                        },
+                        "instructions": {
+                            "type": "object",
+                            "description": "A JSON object specifying the editing operation. Choose ONE of the following: ... "
+                                           "(Your detailed instructions are excellent here and remain unchanged)",
+                        },
+                        "explanation": {
+                            "type": "string",
+                            "description": "A clear and concise justification for why this file modification is necessary.",
+                        },
+                    },
+                },
+            },
+        },{
+            "type": "function",
+            "function": {
+                "name": "edit_file",
+                "description": "Modifies an existing one with a variety of granular operations. "
+                               "It is critical to first inspect the file's content to ensure the edit is appropriate. "
+                               "Always provide a clear explanation for the modification.",
                 "parameters": {
                     "type": "object",
                     "required": ["target_file", "instructions", "explanation"],
@@ -244,9 +272,9 @@ def get_available_tools() -> List[Dict[str, Any]]:
                                "scientific concepts, or detailed biographies.",
                 "parameters": {
                     "type": "object",
-                    "required": ["search_query"],
+                    "required": ["q"],
                     "properties": {
-                        "search_query": {
+                        "q": {
                             "type": "string",
                             "description": "The topic to search for on Wikipedia.",
                         }

--- a/apollo/tools/executor.py
+++ b/apollo/tools/executor.py
@@ -28,7 +28,6 @@ class ToolExecutor:
         """
         self.workspace_path = workspace_path
         self.available_functions = {}
-        self.redirect_mapping = {}
         self.last_edit_file = None
         self.last_edit_content = None
 
@@ -53,7 +52,7 @@ class ToolExecutor:
 
     async def execute_tool(self, tool_call) -> Any:
         """
-        Execute a tool function call (from LLM) with validated arguments and secure redirection.
+        Execute a tool function call (from LLM) with validated arguments
 
         Args:
             tool_call: The tool call from the LLM.
@@ -95,6 +94,7 @@ class ToolExecutor:
             return f"[ERROR] Function '{func_name}' not found."
 
         filtered_args = filter_valid_args(func, arguments_dict)
+        print(f"filtered_args: {filtered_args}")
 
         try:
             if inspect.iscoroutinefunction(func):

--- a/apollo/tools/web.py
+++ b/apollo/tools/web.py
@@ -18,7 +18,7 @@ from bs4 import BeautifulSoup
 from apollo.config.const import Constant
 
 
-async def web_search(search_query: str) -> List[Dict[str, str]]:
+async def web_search(q: str) -> List[Dict[str, str]]:
     """
     Fetches search results from DuckDuckGo using its HTML search page.
 
@@ -27,13 +27,12 @@ async def web_search(search_query: str) -> List[Dict[str, str]]:
     result, its URL, and a snippet (if available). The function returns a list of
     such results structured as dictionaries.
 
-    :param search_query: Search query string to be sent to DuckDuckGo.
-    :type search_query: Str
+    :param q: Str - Search query string to be sent to DuckDuckGo.
     :return: A list of dictionaries, where each dictionary contains 'title', 'url',
         and 'snippet' representing a search result.
     :rtype: List[Dict[str, str]]
     """
-    url = f"https://html.duckduckgo.com/html/?q={quote_plus(search_query)}"
+    url = f"https://html.duckduckgo.com/html/?q={quote_plus(q)}"
     headers = {
         "User-Agent": random.choice(Constant.USER_AGENTS),
     }
@@ -63,7 +62,7 @@ async def web_search(search_query: str) -> List[Dict[str, str]]:
         return results
 
 
-async def wiki_search(search_query: str) -> List[Dict[str, str]]:
+async def wiki_search(q: str) -> List[Dict[str, str]]:
     """
     Fetches search results from Wikipedia for a given query string asynchronously.
 
@@ -74,12 +73,11 @@ async def wiki_search(search_query: str) -> List[Dict[str, str]]:
     The extracted data is returned as a list of dictionaries, each containing
     the title, URL, and snippet of a result.
 
-    :param search_query: The query string to search for on Wikipedia.
-    :type search_query: Str
+    :param q: Str - The query string to search for on Wikipedia.
     :return: A list of dictionaries containing titles, URLs, and snippets of the search results.
     :rtype: List[Dict[str, str]]
     """
-    url = f"https://en.wikipedia.org/w/index.php?search={quote_plus(search_query)}"
+    url = f"https://en.wikipedia.org/w/index.php?search={quote_plus(q)}"
     headers = {
         "User-Agent": random.choice(Constant.USER_AGENTS),
     }


### PR DESCRIPTION
- **Remove "reapply" functionality from agent tools and documentation**
- **Remove inappropriate comment from config constants file**
- **Update year, im out of the time! It's my problem, not AI powa :D**
- **Refactor tools and executors: - Added `wiki_search` function for Wikipedia integration. - Replaced `edit_file` with `edit_file_or_create` for enhanced file editing capabilities. - Removed redundant redirect functionality from `executor`. - Updated tool registration in `ApolloAgent` to reflect changes. - Improved configuration parameters for tools.**
- **Refactor Apollo tools and functionality: - Improved `edit_file_or_create` by refining path handling and directory creation logic for safer operations. - Updated tool configurations for better clarity and documentation. - Enhanced `ApolloAgent` tool registration with more descriptive organization and added comments. - Adjusted descriptions of search and file operation tools for consistency and precision. - Fixed minor issues in `executor.py` and related modules. - Updated README to reflect new tool functionalities (`wiki_search`, `web_search`).**
- **Refactor `edit_file_or_create` and optimize file handling logic: - Separated edit operations into `apply_edit_operation` for better modularity. - Simplified directory creation and file existence checks. - Added more robust handling for JSON and HTML-specific operations. - Reduced redundant error handling and streamlined operation dispatch. - Created `TODO.md` for tracking enhancements and bug fixes.**
- **Separete tool for create and edit file**
